### PR TITLE
Get first actual bytes from Device

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ Options:
 
 // Just dump a list of what was discovered to the console
 func devices(devices []usb.IosDevice) {
-	log.Info("iOS Devices with UsbMux Endpoint:")
+	log.Infof("(%d) iOS Devices with UsbMux Endpoint:", len(devices))
 
 	output := usb.PrintDeviceDetails(devices)
 	log.Info(output)

--- a/usb/messageprocessor.go
+++ b/usb/messageprocessor.go
@@ -1,0 +1,44 @@
+package usb
+
+import (
+	"encoding/hex"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	initialState = iota
+	pingSent = iota
+	pingExchangeCompleted = iota
+)
+
+type messageProcessor struct{
+	connectionState int
+	writeToUsb func([]byte)
+	stopSignal chan interface{}
+}
+
+func NewMessageProcessor(writeToUsb func([]byte), stopSignal chan interface{}) messageProcessor {
+	var mp = messageProcessor{connectionState:initialState, writeToUsb:writeToUsb, stopSignal:stopSignal}
+	return mp
+}
+
+func (mp *messageProcessor) receiveData(data []byte){
+	log.Debugf("Rcv:\n%s", hex.Dump(data))
+	if mp.connectionState == initialState{
+		log.Debug("initial ping received, sending ping back")
+		mp.respondToPing(data)
+		mp.connectionState = pingSent
+		return
+	}
+	if mp.connectionState == pingSent{
+		log.Debug("second ping received, start reading actual data")
+		mp.connectionState = pingExchangeCompleted
+		return
+	}
+	var stop interface{}
+	mp.stopSignal <- stop
+}
+
+func (mp messageProcessor) respondToPing(bytes []byte) {
+	mp.writeToUsb(bytes)
+}

--- a/usb/usbvideostream.go
+++ b/usb/usbvideostream.go
@@ -1,6 +1,7 @@
 package usb
 
 import (
+	"encoding/hex"
 	"github.com/google/gousb"
 	log "github.com/sirupsen/logrus"
 	"time"
@@ -72,30 +73,36 @@ func StartReading(device IosDevice) {
 		log.Fatal("failed control", err)
 		return
 	}
-	log.Infof("Got %d as val ", val)
+	log.Infof("Clear Feature RC: %d", val)
 
 	iface, err := grabQuickTimeInterface(config)
 	if err != nil {
 		log.Fatal("Couldnt get Quicktime Interface")
 		return
 	}
+	log.Debugf("Got QT iface:%s", iface.String())
+
 	inEndpoint, err := iface.InEndpoint(grabInBulk(iface.Setting))
 	if err != nil {
 		log.Fatal("couldnt get InEndpoint")
 		return
 	}
-	stream, err := inEndpoint.NewStream(8, 3)
+	log.Debugf("Inbound Bulk: %s", inEndpoint.String())
+
+	stream, err := inEndpoint.NewStream(512, 1)
 	if err != nil {
 		log.Fatal("couldnt create stream")
 		return
 	}
-	buffer := make([]byte, 70000)
+	log.Debugf("Endpoint claimed: %s", stream)
+
+	buffer := make([]byte, 512)
 	n, err := stream.Read(buffer)
 	if err != nil {
-		log.Fatal("coudlnt read bytes")
+		log.Fatal("coudlnt read bytes", err)
 		return
 	}
-	log.Info("read %d bytes", n)
+	log.Info("read %d bytes:%s", n, hex.Dump(buffer))
 }
 
 func grabInBulk(setting gousb.InterfaceSetting) int {


### PR DESCRIPTION
This PR receives the first actual video bytes from the device after responding to a ping message. 
You still have to run the `activate` command before calling the `dumpraw` command. 