### PR TITLE
Fix restart bug in dumpraw

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ func activate() {
 }
 
 func dumpraw(outFilePath string) {
+	activate()
 	cleanup := screencapture.Init()
 	deviceList, err := screencapture.FindIosDevices()
 	defer cleanup()

--- a/main.go
+++ b/main.go
@@ -39,23 +39,15 @@ The commands work as following:
 	//TODO:add device selection here
 	log.Info(udid)
 
-	cleanup := screencapture.Init()
-	defer cleanup()
-	deviceList, err := screencapture.FindIosDevices()
-
-	if err != nil {
-		log.Fatal("Error finding iOS Devices", err)
-	}
-
 	devicesCommand, _ := arguments.Bool("devices")
 	if devicesCommand {
-		devices(deviceList)
+		devices()
 		return
 	}
 
 	activateCommand, _ := arguments.Bool("activate")
 	if activateCommand {
-		activate(deviceList)
+		activate()
 		return
 	}
 
@@ -66,25 +58,7 @@ The commands work as following:
 			log.Error("Missing outfile parameter. Please specify a valid path like '/home/me/out.h264'")
 			return
 		}
-		log.Infof("Writing output to:%s", outFilePath)
-		dev := deviceList[0]
-		//This channel will get a UDID string whenever a device is connected
-		attachedChannel := make(chan string)
-		listenForDeviceChanges(attachedChannel)
-
-		file, err := os.Create(outFilePath)
-		if err != nil {
-			log.Debugf("Error creating file:%s", err)
-			log.Errorf("Could not open file '%s'", outFilePath)
-		}
-		writer := coremedia.NewNaluFileWriter(bufio.NewWriter(file))
-		adapter := screencapture.UsbAdapter{}
-		stopSignal := make(chan interface{})
-		waitForSigInt(stopSignal)
-		mp := screencapture.NewMessageProcessor(&adapter, stopSignal, writer)
-
-		adapter.StartReading(dev, attachedChannel, &mp, stopSignal)
-		return
+		dumpraw(outFilePath)
 	}
 }
 
@@ -101,24 +75,37 @@ func waitForSigInt(stopSignalChannel chan interface{}) {
 }
 
 // Just dump a list of what was discovered to the console
-func devices(devices []screencapture.IosDevice) {
-	log.Infof("(%d) iOS Devices with UsbMux Endpoint:", len(devices))
+func devices() {
+	cleanup := screencapture.Init()
+	deviceList, err := screencapture.FindIosDevices()
+	defer cleanup()
+	log.Infof("(%d) iOS Devices with UsbMux Endpoint:", len(deviceList))
 
-	output := screencapture.PrintDeviceDetails(devices)
+	if err != nil {
+		log.Fatal("Error finding iOS Devices", err)
+	}
+	output := screencapture.PrintDeviceDetails(deviceList)
 	log.Info(output)
 }
 
 // This command is for testing if we can enable the hidden Quicktime device config
-func activate(devices []screencapture.IosDevice) {
+func activate() {
+	cleanup := screencapture.Init()
+	deviceList, err := screencapture.FindIosDevices()
+	defer cleanup()
+	if err != nil {
+		log.Fatal("Error finding iOS Devices", err)
+	}
+
 	log.Info("iOS Devices with UsbMux Endpoint:")
 
-	output := screencapture.PrintDeviceDetails(devices)
+	output := screencapture.PrintDeviceDetails(deviceList)
 	log.Info(output)
 
 	//This channel will get a UDID string whenever a device is connected
 	attachedChannel := make(chan string)
 	listenForDeviceChanges(attachedChannel)
-	err := screencapture.EnableQTConfig(devices, attachedChannel)
+	err = screencapture.EnableQTConfig(deviceList, attachedChannel)
 	if err != nil {
 		log.Fatal("Error enabling QT config", err)
 	}
@@ -128,11 +115,39 @@ func activate(devices []screencapture.IosDevice) {
 		log.Fatal("Error finding QT Devices", err)
 	}
 	qtOutput := screencapture.PrintDeviceDetails(qtDevices)
-	if len(qtDevices) != len(devices) {
-		log.Warnf("Less qt devices (%d) than plain usbmux devices (%d)", len(qtDevices), len(devices))
+	if len(qtDevices) != len(deviceList) {
+		log.Warnf("Less qt devices (%d) than plain usbmux devices (%d)", len(qtDevices), len(deviceList))
 	}
 	log.Info("iOS Devices with QT Endpoint:")
 	log.Info(qtOutput)
+}
+
+func dumpraw(outFilePath string) {
+	cleanup := screencapture.Init()
+	deviceList, err := screencapture.FindIosDevices()
+	defer cleanup()
+	if err != nil {
+		log.Fatal("Error finding iOS Devices", err)
+	}
+	log.Infof("Writing output to:%s", outFilePath)
+	dev := deviceList[0]
+	//This channel will get a UDID string whenever a device is connected
+	attachedChannel := make(chan string)
+	listenForDeviceChanges(attachedChannel)
+
+	file, err := os.Create(outFilePath)
+	if err != nil {
+		log.Debugf("Error creating file:%s", err)
+		log.Errorf("Could not open file '%s'", outFilePath)
+	}
+	writer := coremedia.NewNaluFileWriter(bufio.NewWriter(file))
+	adapter := screencapture.UsbAdapter{}
+	stopSignal := make(chan interface{})
+	waitForSigInt(stopSignal)
+	mp := screencapture.NewMessageProcessor(&adapter, stopSignal, writer)
+
+	adapter.StartReading(dev, attachedChannel, &mp, stopSignal)
+	return
 }
 
 func listenForDeviceChanges(attachedChannel chan string) {

--- a/screencapture/activator.go
+++ b/screencapture/activator.go
@@ -1,0 +1,53 @@
+package screencapture
+
+import (
+	"github.com/google/gousb"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+// EnableQTConfig enables the hidden QuickTime Device configuration that will expose two new bulk endpoints.
+// We will send a control transfer to the device via USB which will cause the device to disconnect and then
+// re-connect with a new device configuration. Usually the usbmuxd will automatically enable that new config
+// as it will detect it as the device's preferredConfig.
+func EnableQTConfig(devices []IosDevice, attachedDevicesChannel chan string) error {
+	for _, device := range devices {
+		err := enableQTConfigSingleDevice(device, attachedDevicesChannel)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func enableQTConfigSingleDevice(device IosDevice, attachedDevicesChannel chan string) error {
+	if isValidIosDeviceWithActiveQTConfig(device.usbDevice.Desc) {
+		log.Debugf("Skipping %s because it already has an active QT config", device.SerialNumber)
+		return nil
+	}
+
+	err := sendQTConfigControlRequest(device)
+	if err != nil {
+		return err
+	}
+
+	duratio, _ := time.ParseDuration("2s")
+	time.Sleep(duratio)
+	ctx.Close()
+	ctx = gousb.NewContext()
+	device.usbDevice, err = findBySerialNumber(device.SerialNumber)
+
+	return err
+}
+
+func sendQTConfigControlRequest(device IosDevice) error {
+	response := make([]byte, 0)
+	val, err := device.usbDevice.Control(0x40, 0x52, 0x00, 0x02, response)
+
+	if err != nil {
+		log.Fatal("Failed sending control transfer for enabling hidden QT config", err)
+		return err
+	}
+	log.Debugf("Enabling QT config RC:%d", val)
+	return nil
+}

--- a/screencapture/discovery.go
+++ b/screencapture/discovery.go
@@ -1,6 +1,7 @@
 package screencapture
 
 import (
+	"errors"
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"strings"
@@ -64,6 +65,19 @@ func findIosDevices(validDeviceChecker func(desc *gousb.DeviceDesc) bool) ([]Ios
 	}
 
 	return iosDevices, nil
+}
+
+func findBySerialNumber(udid string) (*gousb.Device, error) {
+	devices, err := FindIosDevices()
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range devices {
+		if d.SerialNumber == udid {
+			return d.usbDevice, nil
+		}
+	}
+	return nil, errors.New("not found")
 }
 
 func mapToIosDevice(devices []*gousb.Device) ([]IosDevice, error) {

--- a/screencapture/usbadapter.go
+++ b/screencapture/usbadapter.go
@@ -6,48 +6,6 @@ import (
 	"time"
 )
 
-// EnableQTConfig enables the hidden QuickTime Device configuration that will expose two new bulk endpoints.
-// We will send a control transfer to the device via USB which will cause the device to disconnect and then
-// re-connect with a new device configuration. Usually the usbmuxd will automatically enable that new config
-// as it will detect it as the device's preferredConfig.
-func EnableQTConfig(devices []IosDevice, attachedDevicesChannel chan string) error {
-	for _, device := range devices {
-		err := enableQTConfigSingleDevice(device, attachedDevicesChannel)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func enableQTConfigSingleDevice(device IosDevice, attachedDevicesChannel chan string) error {
-	if isValidIosDeviceWithActiveQTConfig(device.usbDevice.Desc) {
-		log.Debugf("Skipping %s because it already has an active QT config", device.SerialNumber)
-		return nil
-	}
-
-	err := sendQTConfigControlRequest(device)
-	if err != nil {
-		return err
-	}
-	//FIXME: For now we assume just one device on the host
-	attachedUdid := <-attachedDevicesChannel
-	log.Infof("Device '%s' reattached", attachedUdid)
-	return nil
-}
-
-func sendQTConfigControlRequest(device IosDevice) error {
-	response := make([]byte, 0)
-	val, err := device.usbDevice.Control(0x40, 0x52, 0x00, 0x02, response)
-
-	if err != nil {
-		log.Fatal("Failed sending control transfer for enabling hidden QT config", err)
-		return err
-	}
-	log.Debugf("Enabling QT config RC:%d", val)
-	return nil
-}
-
 //UsbAdapter reads and writes from AV Quicktime USB Bulk endpoints
 type UsbAdapter struct {
 	outEndpoint *gousb.OutEndpoint
@@ -64,16 +22,12 @@ func (usa UsbAdapter) writeDataToUsb(bytes []byte) {
 //StartReading claims the AV Quicktime USB Bulk endpoints and starts reading until a stopSignal is sent.
 //Every received data is added to a frameextractor and when it is complete, sent to the UsbDataReceiver.
 func (usa *UsbAdapter) StartReading(device IosDevice, attachedDevicesChannel chan string, receiver UsbDataReceiver, stopSignal chan interface{}) {
-	err := enableQTConfigSingleDevice(device, attachedDevicesChannel)
-	if err != nil {
-		log.Error("Failed enabling QT Config", err)
-		return
-	}
-
-	log.Debugf("Enabling Quicktime Config for %s", device.SerialNumber)
-
 	muxConfig, qtConfig := findConfigurations(device.usbDevice.Desc)
 	device.QTConfigIndex = qtConfig
+	if qtConfig == -1 {
+		log.Error("AV Quicktime USB Config was not enabled")
+		return
+	}
 	device.UsbMuxConfigIndex = muxConfig
 	config, err := device.enableQuickTimeConfig()
 	defer func() {

--- a/screencapture/usbadapter.go
+++ b/screencapture/usbadapter.go
@@ -21,7 +21,7 @@ func (usa UsbAdapter) writeDataToUsb(bytes []byte) {
 
 //StartReading claims the AV Quicktime USB Bulk endpoints and starts reading until a stopSignal is sent.
 //Every received data is added to a frameextractor and when it is complete, sent to the UsbDataReceiver.
-func (usa *UsbAdapter) StartReading(device IosDevice, attachedDevicesChannel chan string, receiver UsbDataReceiver, stopSignal chan interface{}) {
+func (usa *UsbAdapter) StartReading(device IosDevice, receiver UsbDataReceiver, stopSignal chan interface{}) {
 	muxConfig, qtConfig := findConfigurations(device.usbDevice.Desc)
 	device.QTConfigIndex = qtConfig
 	if qtConfig == -1 {


### PR DESCRIPTION
Dumpraw command works now without the need of starting it twice.
I removed the dependency on usbmux as it does not work on linux anyway. 
Ubuntu by default closes usbmuxd when the last device was removed. 
Now I changed the code to use polling.
Also I close and open a new LibUsb context every time because otherwise the new config will not be detected correctly. 