### PR TITLE
Fix zlp bug

### DIFF
--- a/screencapture/activator.go
+++ b/screencapture/activator.go
@@ -32,11 +32,11 @@ func enableQTConfigSingleDevice(device IosDevice) error {
 	if err != nil {
 		return err
 	}
-	duration, _ := time.ParseDuration("500ms")
+
 	var i int
 	for {
 		log.Infof("Checking for active QT config for %s", udid)
-		time.Sleep(duration)
+		time.Sleep(500 * time.Millisecond)
 		err = ctx.Close()
 		if err != nil {
 			log.Warn("failed closing context", err)
@@ -64,8 +64,7 @@ func sendQTConfigControlRequest(device IosDevice) error {
 	val, err := device.usbDevice.Control(0x40, 0x52, 0x00, 0x02, response)
 
 	if err != nil {
-		log.Fatal("Failed sending control transfer for enabling hidden QT config", err)
-		return err
+		log.Warn("Failed sending control transfer for enabling hidden QT config. Seems like this happens sometimes but it still works usually.", err)
 	}
 	log.Debugf("Enabling QT config RC:%d", val)
 	return nil

--- a/screencapture/frameextractor_test.go
+++ b/screencapture/frameextractor_test.go
@@ -18,6 +18,13 @@ func TestCompletePacket(t *testing.T) {
 	frame1, frameReturned2 := fe.ExtractFrame(small)
 	assert.True(t, frameReturned2)
 	assert.Equal(t, small[4:], frame1)
+
+}
+
+func TestZeroLengthPacket(t *testing.T) {
+	fe := screencapture.NewLengthFieldBasedFrameExtractor()
+	_, frameReturned := fe.ExtractFrame(make([]byte, 0))
+	assert.False(t, frameReturned)
 }
 
 func TestIncompletePacket(t *testing.T) {


### PR DESCRIPTION
Receiving a zero length byte array crashed the frameextractor. 