### PR TITLE
Gstreamer AppSource Implementation for AV playback on the desktop

### DIFF
--- a/screencapture/coremedia/wav_format.go
+++ b/screencapture/coremedia/wav_format.go
@@ -113,25 +113,33 @@ func writeWavDataSubChunkHeader(target *bytes.Buffer, dataLength int) error {
 //WriteWavHeader creates a wave file header using the given length and writes it at the BEGINNING of the wavFile.
 //Please make sure that the file has enough zero bytes before the audio data.
 func WriteWavHeader(length int, wavFile *os.File) error {
+	headerBytes, err := GetWavHeaderBytes(length)
+	if err != nil {
+		return err
+	}
+	_, err = wavFile.WriteAt(headerBytes, 0)
+	return err
+}
+
+func GetWavHeaderBytes(length int) ([]byte, error) {
 	buffer := bytes.NewBuffer(make([]byte, 100))
 	buffer.Reset()
 
 	riffHeader := newRiffHeader(length)
 	err := riffHeader.serialize(buffer)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fmtSubChunk := newFmtSubChunk()
 	err = fmtSubChunk.serialize(buffer)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = writeWavDataSubChunkHeader(buffer, length)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = wavFile.WriteAt(buffer.Bytes(), 0)
-	return err
+	return buffer.Bytes(), nil
 }

--- a/screencapture/frameextractor.go
+++ b/screencapture/frameextractor.go
@@ -32,8 +32,8 @@ func (fe *LengthFieldBasedFrameExtractor) ExtractFrame(bytes []byte) ([]byte, bo
 		return fe.handleNewFrame(bytes)
 	}
 	if fe.readyForNextFrame && fe.frameBuffer.Len() != 0 {
-		if fe.frameBuffer.Len()<4{
-			log.Fatal("wtf:"+hex.Dump(fe.frameBuffer.Bytes()))
+		if fe.frameBuffer.Len() < 4 {
+			log.Fatal("wtf:" + hex.Dump(fe.frameBuffer.Bytes()))
 		}
 		fe.nextFrameSize = int(binary.LittleEndian.Uint32(fe.frameBuffer.Next(4))) - 4
 		fe.readyForNextFrame = false

--- a/screencapture/frameextractor.go
+++ b/screencapture/frameextractor.go
@@ -33,6 +33,9 @@ func (fe *LengthFieldBasedFrameExtractor) ExtractFrame(bytes []byte) ([]byte, bo
 	}
 	if fe.readyForNextFrame && fe.frameBuffer.Len() != 0 {
 		if fe.frameBuffer.Len() < 4 {
+			/* examples:
+			FATA[0032] wtf:00000000  ac 10                                             |..|
+			*/
 			log.Fatal("wtf:" + hex.Dump(fe.frameBuffer.Bytes()))
 		}
 		fe.nextFrameSize = int(binary.LittleEndian.Uint32(fe.frameBuffer.Next(4))) - 4

--- a/screencapture/gstadapter/gst_adapter.go
+++ b/screencapture/gstadapter/gst_adapter.go
@@ -20,6 +20,17 @@ type GstAdapter struct {
 
 func New() *GstAdapter {
 	log.Info("Starting Gstreamer..")
+
+	asrc, pl := setUpVideoPipeline()
+
+	pl.SetState(gst.STATE_PLAYING)
+
+	log.Info("Gstreamer is running!")
+	gsta := GstAdapter{appSrc: asrc}
+	return &gsta
+}
+
+func setUpVideoPipeline() (*gst.AppSrc, *gst.Pipeline) {
 	asrc := gst.NewAppSrc("my-video-src")
 	asrc.SetProperty("is-live", true)
 
@@ -42,12 +53,7 @@ func New() *GstAdapter {
 	h264parse.Link(avdec_h264)
 	avdec_h264.Link(videoconvert)
 	videoconvert.Link(sink)
-
-	pl.SetState(gst.STATE_PLAYING)
-
-	log.Info("Gstreamer is running!")
-	gsta := GstAdapter{appSrc: asrc}
-	return &gsta
+	return asrc, pl
 }
 
 func checkElem(e *gst.Element, name string) {


### PR DESCRIPTION
I added GoBindings for Gstreamer and built two pipelines for audio and video so you can finally get a live AV Stream and watch whatever is going on on your device in a Desktop window. 

For some reason the Audio pipeline only works with an ugly hack. Gstreamer cannot play the uncompressed PCM data just like that while encoding it and streaming it works perfectly fine.
As a hacky workaround, I am encoding audio to ogg just to decode it right after to make audio work. Otherwise the autoaudiosink stays silent. 