### PR TITLE
Add custom gst pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Currently you can use it to dump a h264 file and a wave file or mirror your devi
 
 ## 2. Installation
 
-1. Install Gstreamer and LibUSB with brew or apt depending on your platform.
+1. Install Gstreamer and LibUSB with brew or apt depending on your platform. 
+   Run `brew install libusb` and `brew install pkg-config` and `brew install gstreamer gst-plugins-bad gst-plugins-good gst-plugins-base gst-plugins-ugly`
 3. Download the latest release and run it
 
 ### MAC OS X LIBUSB -- IMPORTANT

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Currently you can use it to dump a h264 file and a wave file or mirror your devi
 
 ## 3. Usage
 ```
-Q.uickTime V.ideo H.ack (qvh) v0.2-beta
+Q.uickTime V.ideo H.ack (qvh) v0.3-beta
 
 Usage:
   qvh devices [-v]
   qvh activate [--udid=<udid>] [-v]
   qvh record <h264file> <wavfile> [-v] [--udid=<udid>]
-  qvh gstreamer [-v]
+  qvh gstreamer [--pipeline=<pipeline>] [--examples] [-v]
   qvh --version | version
 
 
@@ -41,12 +41,15 @@ Options:
   --udid=<udid>   UDID of the device. If not specified, the first found device will be used automatically.
 
 The commands work as following:
-	devices		lists iOS devices attached to this host and tells you if video streaming was activated for them
-	activate	enables the video streaming config for the device specified by --udid
-	record		will start video&audio recording. Video will be saved in a raw h264 file playable by VLC.
-				Audio will be saved in a uncompressed wav file.
-				Run like: "qvh record /home/yourname/out.h264 /home/yourname/out.wav"
-	gstreamer   qvh will open a new window and push AV data to gstreamer.
+        devices         lists iOS devices attached to this host and tells you if video streaming was activated for them
+        activate        enables the video streaming config for the device specified by --udid
+        record          will start video&audio recording. Video will be saved in a raw h264 file playable by VLC. 
+                     Audio will be saved in a uncompressed wav file. Run like: "qvh record /home/yourname/out.h264 /home/yourname/out.wav"
+
+        gstreamer   If no additional param is provided, qvh will open a new window and push AV data to gstreamer.
+                                If "qvh gstreamer --examples" is provided, qvh will print some common gstreamer pipeline examples.
+                                If --pipeline is provided, qvh will use the provided gstreamer pipeline instead of 
+                                displaying audio and video in a window. 
 ```
 
 ## 3. Technical Docs/ Roll your own implementation

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Currently you can use it to dump a h264 file and a wave file or mirror your devi
 
 ## 2. Installation
 
-Install Gstreamer and LibUSB
+1. Install Gstreamer and LibUSB with brew or apt depending on your platform.
+3. Download the latest release and run it
 
 ### MAC OS X LIBUSB -- IMPORTANT
 1. Make sure to use either this fork `https://github.com/GroundControl-Solutions/libusb`

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/danielpaulus/go-ios v0.0.0-20190926190740-cc977db05eea
-	github.com/danielpaulus/gst v0.0.0-20191031112308-dfcba780ec66
+	github.com/danielpaulus/gst v0.0.0-20200201205042-e6d2974fceb8
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/google/gousb v0.0.0-20190812193832-18f4c1d8a750
 	github.com/lijo-jose/glib v0.0.0-20191012030101-93ee72d7d646

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/danielpaulus/gst v0.0.0-20191031102428-eb100cb83442 h1:AKA48ahee1DRBV
 github.com/danielpaulus/gst v0.0.0-20191031102428-eb100cb83442/go.mod h1:JbhjLST5AaUXpKQK65g9144BK8QHftbpuFoYuhDuONw=
 github.com/danielpaulus/gst v0.0.0-20191031112308-dfcba780ec66 h1:UDoHlePd6+rNFfJ/s2ASd2MTRE0W1sWzCeujJVTjVKU=
 github.com/danielpaulus/gst v0.0.0-20191031112308-dfcba780ec66/go.mod h1:JbhjLST5AaUXpKQK65g9144BK8QHftbpuFoYuhDuONw=
+github.com/danielpaulus/gst v0.0.0-20200201205042-e6d2974fceb8 h1:+XiTgRoo1bCA3paC4e/0WYWI7+J2O7hR/IYuSikANMw=
+github.com/danielpaulus/gst v0.0.0-20200201205042-e6d2974fceb8/go.mod h1:JbhjLST5AaUXpKQK65g9144BK8QHftbpuFoYuhDuONw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -116,13 +116,13 @@ func printExamples() {
 	examples := `Examples:
 	This pipeline will save the recording in video.mp4 with h264 and aac format. The default settings 
 	of this pipeline will create a compressed video that takes up way less space than raw h264.
+	Note that you need to set "ignore-length" on the wavparse because we are streaming and do not know the length in advance.
 
-qvh gstreamer --pipeline "mp4mux name=mux ! filesink location=video.mp4 \
-queue name=audio_target ! wavparse ! audioconvert ! queue ! faac ! mux. \
-queue name=video_target ! h264parse ! vtdec ! videoconvert ! x264enc  tune=zerolatency !  mux."
-
+	qvh gstreamer --pipeline "qtmux name=mux ! filesink location=video.mp4 \
+	queue name=audio_target ! wavparse ignore-length=true ! audioconvert ! faac ! aacparse ! mux. \
+	queue name=video_target ! h264parse ! vtdec ! videoconvert ! x264enc  tune=zerolatency !  mux."
 	`
-	print(examples)
+	fmt.Print(examples)
 }
 
 func startGStreamerWithCustomPipeline(udid string, pipelineString string) {

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version = "v0.2-beta"
+const version = "v0.3-beta"
 
 func main() {
 	usage := fmt.Sprintf(`Q.uickTime V.ideo H.ack (qvh) %s

--- a/main.go
+++ b/main.go
@@ -114,11 +114,13 @@ func printVersion() {
 func printExamples() {
 
 	examples := `Examples:
+	
+	Writing an MP4 file
 	This pipeline will save the recording in video.mp4 with h264 and aac format. The default settings 
 	of this pipeline will create a compressed video that takes up way less space than raw h264.
 	Note that you need to set "ignore-length" on the wavparse because we are streaming and do not know the length in advance.
 
-	Write MP$ file Mac OSX: 
+	Write MP4 file Mac OSX: 
 	vtdec is the hardware accelerated decoder on the mac. 
 
 	qvh gstreamer --pipeline "mp4mux name=mux ! filesink location=video.mp4 \
@@ -245,7 +247,7 @@ func startWithConsumer(consumer screencapture.CmSampleBufConsumer, udid string) 
 	mp := screencapture.NewMessageProcessor(&adapter, stopSignal, consumer)
 
 	err = adapter.StartReading(device, &mp, stopSignal)
-	consumer.(*gstadapter.GstAdapter).Stop()
+	consumer.Stop()
 	if err != nil {
 		printErrJSON(err, "failed connecting to usb")
 	}

--- a/main.go
+++ b/main.go
@@ -118,7 +118,10 @@ func printExamples() {
 	of this pipeline will create a compressed video that takes up way less space than raw h264.
 	Note that you need to set "ignore-length" on the wavparse because we are streaming and do not know the length in advance.
 
-	qvh gstreamer --pipeline "qtmux name=mux ! filesink location=video.mp4 \
+	Mac OSX: 
+	vtdec is the hardware accelerated decoder on the mac. 
+
+	qvh gstreamer --pipeline "mp4mux name=mux ! filesink location=video.mp4 \
 	queue name=audio_target ! wavparse ignore-length=true ! audioconvert ! faac ! aacparse ! mux. \
 	queue name=video_target ! h264parse ! vtdec ! videoconvert ! x264enc  tune=zerolatency !  mux."
 	`

--- a/main.go
+++ b/main.go
@@ -112,12 +112,17 @@ func printVersion() {
 }
 
 func printExamples() {
-	/*
-			gst-launch-1.0 -e mp4mux name=mux ! filesink location=video.mp4 \
-		audiotestsrc ! queue name=audio_target ! audioconvert ! queue ! faac ! mux. \
-		videotestsrc ! queue name=video_target ! x264enc ! mux.
-	*/
-	print("gstreamer examples will be added here later")
+
+	examples := `Examples:
+	This pipeline will save the recording in video.mp4 with h264 and aac format. The default settings 
+	of this pipeline will create a compressed video that takes up way less space than raw h264.
+
+qvh gstreamer --pipeline "mp4mux name=mux ! filesink location=video.mp4 \
+queue name=audio_target ! wavparse ! audioconvert ! queue ! faac ! mux. \
+queue name=video_target ! h264parse ! vtdec ! videoconvert ! x264enc  tune=zerolatency !  mux."
+
+	`
+	print(examples)
 }
 
 func startGStreamerWithCustomPipeline(udid string, pipelineString string) {
@@ -226,9 +231,11 @@ func startWithConsumer(consumer screencapture.CmSampleBufConsumer, udid string) 
 	adapter := screencapture.UsbAdapter{}
 	stopSignal := make(chan interface{})
 	waitForSigInt(stopSignal)
+
 	mp := screencapture.NewMessageProcessor(&adapter, stopSignal, consumer)
 
 	err = adapter.StartReading(device, &mp, stopSignal)
+	consumer.(*gstadapter.GstAdapter).Stop()
 	if err != nil {
 		printErrJSON(err, "failed connecting to usb")
 	}

--- a/main.go
+++ b/main.go
@@ -112,6 +112,11 @@ func printVersion() {
 }
 
 func printExamples() {
+	/*
+			gst-launch-1.0 -e mp4mux name=mux ! filesink location=video.mp4 \
+		audiotestsrc ! queue name=audio_target ! audioconvert ! queue ! faac ! mux. \
+		videotestsrc ! queue name=video_target ! x264enc ! mux.
+	*/
 	print("gstreamer examples will be added here later")
 }
 

--- a/screencapture/coremedia/avfilewriter.go
+++ b/screencapture/coremedia/avfilewriter.go
@@ -30,6 +30,9 @@ func (avfw AVFileWriter) Consume(buf CMSampleBuffer) error {
 	return avfw.consumeVideo(buf)
 }
 
+//Nothing currently
+func (avfw AVFileWriter) Stop() {}
+
 func (avfw AVFileWriter) consumeVideo(buf CMSampleBuffer) error {
 	if buf.HasFormatDescription {
 		err := avfw.writeNalu(buf.FormatDescription.PPS)

--- a/screencapture/gstadapter/gst_adapter_linux.go
+++ b/screencapture/gstadapter/gst_adapter_linux.go
@@ -21,6 +21,9 @@ type GstAdapter struct {
 	firstAudioSample bool
 }
 
+const audioAppSrcTargetElementName = "audio_target"
+const videoAppSrcTargetElementName = "video_target"
+
 //New creates a new MAC OSX compatible gstreamer pipeline that will play device video and audio
 //in a nice little window :-D
 func New() *GstAdapter {

--- a/screencapture/gstadapter/gst_adapter_linux.go
+++ b/screencapture/gstadapter/gst_adapter_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/danielpaulus/gst"
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
@@ -18,6 +19,7 @@ import (
 type GstAdapter struct {
 	videoAppSrc      *gst.AppSrc
 	audioAppSrc      *gst.AppSrc
+	pipeline         *gst.Pipeline
 	firstAudioSample bool
 }
 

--- a/screencapture/gstadapter/gst_adapter_linux.go
+++ b/screencapture/gstadapter/gst_adapter_linux.go
@@ -39,6 +39,44 @@ func New() *GstAdapter {
 	return &gsta
 }
 
+//NewWithCustomPipeline will parse the given pipelineString, connect the videoAppSrc to whatever element has the name "video_target" and the audioAppSrc to "audio_target"
+//see also: https://gstreamer.freedesktop.org/documentation/application-development/appendix/programs.html?gi-language=c
+func NewWithCustomPipeline(pipelineString string) (*GstAdapter, error) {
+	log.Info("Starting Gstreamer..")
+	log.WithFields(log.Fields{"custom_pipeline": pipelineString}).Debug("Starting Gstreamer with custom pipeline")
+	pipeline, err := gst.ParseLaunch(pipelineString)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid Pipeline, checkout --examples for help. Gstreamer parsing error was: %s", err)
+	}
+
+	audioAppSrcTargetElement := pipeline.AsBin().GetByName(audioAppSrcTargetElementName)
+	if audioAppSrcTargetElement == nil {
+		return nil, fmt.Errorf("The pipeline needs an element with a property 'name=%s' so I can link the audio source to it. run with --examples for details.", audioAppSrcTargetElementName)
+	}
+
+	videoAppSrcTargetElement := pipeline.AsBin().GetByName(videoAppSrcTargetElementName)
+	if videoAppSrcTargetElement == nil {
+		return nil, fmt.Errorf("The pipeline needs an element with a property 'name=%s' so I can link the video source to it. run with --examples for details.", videoAppSrcTargetElementName)
+	}
+
+	videoAppSrc := gst.NewAppSrc("my-video-src")
+	videoAppSrc.SetProperty("is-live", true)
+
+	audioAppSrc := gst.NewAppSrc("my-audio-src")
+	audioAppSrc.SetProperty("is-live", true)
+
+	audioAppSrc.Link(audioAppSrcTargetElement)
+	videoAppSrc.Link(videoAppSrcTargetElement)
+
+	pipeline.SetState(gst.STATE_PLAYING)
+	runGlibMainLoop()
+
+	log.Info("Gstreamer is running!")
+	gsta := GstAdapter{videoAppSrc: videoAppSrc, audioAppSrc: audioAppSrc, firstAudioSample: true}
+
+	return &gsta, nil
+}
+
 //runGlibMainLoop starts the glib Mainloop necessary for the video player to work on MAC OS X.
 func runGlibMainLoop() {
 	go func() {

--- a/screencapture/gstadapter/gst_adapter_macos.go
+++ b/screencapture/gstadapter/gst_adapter_macos.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/danielpaulus/gst"
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
@@ -18,6 +19,7 @@ import (
 type GstAdapter struct {
 	videoAppSrc      *gst.AppSrc
 	audioAppSrc      *gst.AppSrc
+	pipeline         *gst.Pipeline
 	firstAudioSample bool
 }
 
@@ -75,12 +77,32 @@ func NewWithCustomPipeline(pipelineString string) (*GstAdapter, error) {
 	videoAppSrc.Link(videoAppSrcTargetElement)
 
 	pipeline.SetState(gst.STATE_PLAYING)
-	runGlibMainLoop()
+	//runGlibMainLoop()
 
 	log.Info("Gstreamer is running!")
-	gsta := GstAdapter{videoAppSrc: videoAppSrc, audioAppSrc: audioAppSrc, firstAudioSample: true}
+	gsta := GstAdapter{videoAppSrc: videoAppSrc, audioAppSrc: audioAppSrc, firstAudioSample: true, pipeline: pipeline}
 
 	return &gsta, nil
+}
+
+//Stop sends an EOS (end of stream) event downstream the gstreamer pipeline.
+//Some Elements need this to correctly finish. F.ex. writing mp4 video without
+//sending EOS will result in a broken mp4 file
+func (gsta GstAdapter) Stop() {
+	log.Info("Stopping Gstreamer..")
+	success := gsta.audioAppSrc.SendEvent(gst.Eos())
+	if !success {
+		log.Warn("Failed sending EOS signal for audio app source")
+	}
+	success = gsta.videoAppSrc.SendEvent(gst.Eos())
+	if !success {
+		log.Warn("Failed sending EOS signal for video app source")
+	}
+	//FIXME: This is an async operation, I probably should wait for some event here
+	//instead of sleeping :-)
+	time.Sleep(time.Second * 1)
+	gsta.pipeline.SetState(gst.STATE_PAUSED)
+	log.Info("OK.")
 }
 
 //runGlibMainLoop starts the glib Mainloop necessary for the video player to work on MAC OS X.

--- a/screencapture/gstadapter/gst_adapter_macos.go
+++ b/screencapture/gstadapter/gst_adapter_macos.go
@@ -68,6 +68,9 @@ func NewWithCustomPipeline(pipelineString string) (*GstAdapter, error) {
 	audioAppSrc := gst.NewAppSrc("my-audio-src")
 	audioAppSrc.SetProperty("is-live", true)
 
+	pipeline.Add(videoAppSrc.AsElement())
+	pipeline.Add(audioAppSrc.AsElement())
+
 	audioAppSrc.Link(audioAppSrcTargetElement)
 	videoAppSrc.Link(videoAppSrcTargetElement)
 

--- a/screencapture/gstadapter/gst_adapter_macos.go
+++ b/screencapture/gstadapter/gst_adapter_macos.go
@@ -99,7 +99,9 @@ func (gsta GstAdapter) Stop() {
 	}
 
 	bus := gsta.pipeline.GetBus()
-	msg := bus.TimedPopFiltered(1000000000*1000*30, gst.MESSAGE_EOS|gst.MESSAGE_ERROR)
+
+	//I hope those are 60 seconds
+	msg := bus.TimedPopFiltered(1000000000*1000*60, gst.MESSAGE_EOS|gst.MESSAGE_ERROR)
 	if msg == nil {
 		log.Warn("No EOS received, video files might be broken")
 		return

--- a/screencapture/gstadapter/gst_adapter_macos.go
+++ b/screencapture/gstadapter/gst_adapter_macos.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/danielpaulus/gst"
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
@@ -98,11 +97,20 @@ func (gsta GstAdapter) Stop() {
 	if !success {
 		log.Warn("Failed sending EOS signal for video app source")
 	}
-	//FIXME: This is an async operation, I probably should wait for some event here
-	//instead of sleeping :-)
-	time.Sleep(time.Second * 1)
-	gsta.pipeline.SetState(gst.STATE_PAUSED)
-	log.Info("OK.")
+
+	bus := gsta.pipeline.GetBus()
+	msg := bus.TimedPopFiltered(1000000000*1000*30, gst.MESSAGE_EOS|gst.MESSAGE_ERROR)
+	if msg == nil {
+		log.Warn("No EOS received, video files might be broken")
+		return
+	}
+	if msg.GetType() == gst.MESSAGE_ERROR {
+		log.Warn("Error received, video files might be broken")
+		return
+	}
+	log.Info("EOS received")
+	gsta.pipeline.SetState(gst.STATE_NULL)
+	log.Info("Gstreamer finished")
 }
 
 //runGlibMainLoop starts the glib Mainloop necessary for the video player to work on MAC OS X.

--- a/screencapture/gstadapter/gst_adapter_test.go
+++ b/screencapture/gstadapter/gst_adapter_test.go
@@ -1,0 +1,24 @@
+package gstadapter_test
+
+import (
+	"testing"
+
+	"github.com/danielpaulus/quicktime_video_hack/screencapture/gstadapter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomPipelineParsing(t *testing.T) {
+
+	_, err := gstadapter.NewWithCustomPipeline("daniel")
+	assert.Error(t, err)
+
+	_, err = gstadapter.NewWithCustomPipeline("queue name=my_filesrc ! fakesink")
+	assert.Error(t, err)
+
+	_, err = gstadapter.NewWithCustomPipeline("queue name=audio_target ! fakesink")
+	assert.Error(t, err)
+
+	gsta, err := gstadapter.NewWithCustomPipeline("rtpmux name=mux ! fakesink \n queue name=audio_target ! mux.sink_0 \n queue name=video_target ! mux.sink_1")
+	assert.NoError(t, err)
+	assert.NotNil(t, gsta)
+}

--- a/screencapture/interfaces.go
+++ b/screencapture/interfaces.go
@@ -5,6 +5,7 @@ import "github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
 //CmSampleBufConsumer is a simple interface with one function that consumes CMSampleBuffers
 type CmSampleBufConsumer interface {
 	Consume(buf coremedia.CMSampleBuffer) error
+	Stop()
 }
 
 //UsbDataReceiver should receive USB SYNC, ASYN and PING packets with the correct length and with the 4 bytes length removed.

--- a/screencapture/messageprocessor_test.go
+++ b/screencapture/messageprocessor_test.go
@@ -23,6 +23,8 @@ func (u UsbTestDummy) Consume(buf coremedia.CMSampleBuffer) error {
 	return nil
 }
 
+func (u UsbTestDummy) Stop() {}
+
 func (u UsbTestDummy) WriteDataToUsb(data []byte) {
 	u.dataReceiver <- data
 }


### PR DESCRIPTION
This PR introduces new switches to the gstreamer command:
`--pipeline <gstreamer_pipeline_string` allows users to specify their own custom gstreamer pipelines that qvh will pump the AV data into. This can be used for WebRTC/RTP/transcoding purposes.

`--examples` shows how it's done because building correct gstreamer pipelines can be quite tricky. 