### PR TITLE
Ignore the broken packets instead of crashing the tool

### DIFF
--- a/screencapture/frameextractor.go
+++ b/screencapture/frameextractor.go
@@ -42,7 +42,8 @@ func (fe *LengthFieldBasedFrameExtractor) ExtractFrame(bytes []byte) ([]byte, bo
 			/*
 				{"level":"fatal","msg":"wtf:00000000  ac 10 00                                          |...|\n","time":"2019-11-18T12:12:11+01:00"}
 			*/
-			log.Fatal("wtf:" + hex.Dump(fe.frameBuffer.Bytes()))
+			log.Warn("received invalid message, dropping:" + hex.Dump(fe.frameBuffer.Bytes()))
+			return nil, false
 		}
 		fe.nextFrameSize = int(binary.LittleEndian.Uint32(fe.frameBuffer.Next(4))) - 4
 		fe.readyForNextFrame = false

--- a/screencapture/gstadapter/gst_adapter_linux.go
+++ b/screencapture/gstadapter/gst_adapter_linux.go
@@ -89,6 +89,10 @@ func NewWithCustomPipeline(pipelineString string) (*GstAdapter, error) {
 //sending EOS will result in a broken mp4 file
 func (gsta GstAdapter) Stop() {
 	log.Info("Stopping Gstreamer..")
+	if gsta.pipeline == nil {
+		log.Info("Pipeline already freed. Not sending EOS")
+		return
+	}
 	success := gsta.audioAppSrc.SendEvent(gst.Eos())
 	if !success {
 		log.Warn("Failed sending EOS signal for audio app source")

--- a/screencapture/gstadapter/gst_adapter_macos.go
+++ b/screencapture/gstadapter/gst_adapter_macos.go
@@ -89,6 +89,10 @@ func NewWithCustomPipeline(pipelineString string) (*GstAdapter, error) {
 //sending EOS will result in a broken mp4 file
 func (gsta GstAdapter) Stop() {
 	log.Info("Stopping Gstreamer..")
+	if gsta.pipeline == nil {
+		log.Info("Pipeline already freed. Not sending EOS")
+		return
+	}
 	success := gsta.audioAppSrc.SendEvent(gst.Eos())
 	if !success {
 		log.Warn("Failed sending EOS signal for audio app source")


### PR DESCRIPTION
Intermittently I get weird packets with less than 4 bytes although it should always be a 4 byte integer to specify the length of the next packet. 
Let's see what happens if I just throw away the weird message. 