### PR TITLE
Add diagnostics mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ quicktime_video_hack
 *.mp3
 # Binaries for programs and plugins
 main
+*.csv
 *.h264
 out.wav
 *.exe

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/danielpaulus/quicktime_video_hack) 
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/danielpaulus/quicktime_video_hack)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CircleCI](https://circleci.com/gh/danielpaulus/quicktime_video_hack.svg?style=svg)](https://circleci.com/gh/danielpaulus/quicktime_video_hack)
@@ -6,7 +6,12 @@
 [![Go Report](https://goreportcard.com/badge/github.com/danielpaulus/quicktime_video_hack)](https://goreportcard.com/report/github.com/danielpaulus/quicktime_video_hack)
 
 🎉🎉 New Release 0.5 is out, now with stable execution on Mac OS X, no more unplugging devices 🎉🎉🎉🎉🎉🎉
+
+Qvh without Gstreamer is stable. I ran it for 16 hours straight on parallel devices and it worked flawlessly.
+Before a 1.0 Release I need to see if Gstreamer is stable enough.
+
 ## 1. What is this?
+
 This is an Operating System indepedent implementation for Quicktime Screensharing for iOS devices :-)
 
 [Check out my presentation](https://danielpaulus.github.io/quicktime_video_hack_presentation)
@@ -16,28 +21,38 @@ This is an Operating System indepedent implementation for Quicktime Screensharin
 This repository contains all the code you will need to grab and record video and audio from one or more iPhone(s) or iPad(s)
 without needing one of these expensive MacOS X computers or the hard to use QuickTime Player :-D
 
-- You can record video and audio as raw h264 and wave audio in the Apple demonstration mode (Device shows 9:41am, full battery and no cellphone carrier in the status bar) 
+- You can record video and audio as raw h264 and wave audio in the Apple demonstration mode (Device shows 9:41am, full battery and no cellphone carrier in the status bar)
 - Also you can just grab device audio as wave, ogg or mp3 without the Apple demonstration mode now 🎉
 - You can use custom Gstreamer Pipelines to transcode the AV data into whatever you like
+
 ## 1.2 What's next?
-I will work on stabilizing Linux support next. On my current ubuntu box I need to disable the Camera mode, kill usbmuxd and restart the tool like 20 times before it works. It's really hard to get going. 
-Also, let me know if you have ideas what needs to be added. 
+
+I will work on stabilizing Linux support next. On my current ubuntu box I need to disable the Camera mode, kill usbmuxd and restart the tool like 20 times before it works. It's really hard to get going.
+Also, let me know if you have ideas what needs to be added.
 
 ## 2. Installation
+
 ### 2.1 Mac OSX
+
 1. On MacOS run `brew install libusb pkg-config gstreamer gst-plugins-bad gst-plugins-good gst-plugins-base gst-plugins-ugly`
 2. To just run: Download the latest release and run it
 3. To develop: Clone the repo and execute `go run main.go` (need to install golang of course)
+
 ### 2.2 Linux
-1. Run with Docker: the Docker files are [here](https://github.com/danielpaulus/quicktime_video_hack/tree/master/docker). There is one for just building and one for running. 
+
+1. Run with Docker: the Docker files are [here](https://github.com/danielpaulus/quicktime_video_hack/tree/master/docker). There is one for just building and one for running.
 
 2. If you want to build/run locally then copy paste the dependencies from this [Dockerfile](https://github.com/danielpaulus/quicktime_video_hack/blob/master/docker/Dockerfile.debian) and install with apt.
 3. Git clone the repo and start hacking or download the latest release and run the binary :-D
 
-
 ## 3. Usage
+
+- For just displaying the screen run `qvh gstreamer` and it will work.
+- For troubleshooting run `qvh diagnostics metrics.csv --dump=binary.bin` which will log all important and dump everything to files.
+- For just getting raw media output without Gstreamer involved use `qvh record out.h264 out.wav` or `qvh audio out.wav --wav` for audio only
+
 ```
-Q.uickTime V.ideo H.ack (qvh) v0.5-beta
+Q.uickTime V.ideo H.ack (qvh) v0.6-beta
 
 Usage:
   qvh devices [-v]
@@ -45,6 +60,7 @@ Usage:
   qvh record <h264file> <wavfile> [--udid=<udid>] [-v]
   qvh audio <outfile> (--mp3 | --ogg | --wav) [--udid=<udid>] [-v]
   qvh gstreamer [--pipeline=<pipeline>] [--examples] [--udid=<udid>] [-v]
+  qvh diagnostics <outfile> [--dump=<dumpfile>] [--udid=<udid>]
   qvh --version | version
 
 
@@ -55,31 +71,35 @@ Options:
   --udid=<udid>   UDID of the device. If not specified, the first found device will be used automatically.
 
 The commands work as following:
-	devices		lists iOS devices attached to this host and tells you if video streaming was activated for them
+        devices         lists iOS devices attached to this host and tells you if video streaming was activated for them
 
-	activate	enables the video streaming config for the device specified by --udid
+        activate        enables the video streaming config for the device specified by --udid
 
-	record		will start video&audio recording. Video will be saved in a raw h264 file playable by VLC.
-	            	Audio will be saved in a uncompressed wav file. Run like: "qvh record /home/yourname/out.h264 /home/yourname/out.wav"
+        record          will start video&audio recording. Video will be saved in a raw h264 file playable by VLC.
+                        Audio will be saved in a uncompressed wav file. Run like: "qvh record /home/yourname/out.h264 /home/yourname/out.wav"
 
-	audio		Records only audio from the device. It does not change the status bar like the video recording mode does.
-			The recorded audio will be saved in <outfile> with the selected format. Currently (--mp3 | --ogg | --wav) are supported.
-			Adding more formats is trivial though so create an issue or a PR if you need something :-)
+        audio           Records only audio from the device. It does not change the status bar like the video recording mode does.
+                        The recorded audio will be saved in <outfile> with the selected format. Currently (--mp3 | --ogg | --wav) are supported.
+                        Adding more formats is trivial though so create an issue or a PR if you need something :-)
 
-	gstreamer	If no additional param is provided, qvh will open a new window and push AV data to gstreamer.
-			If "qvh gstreamer --examples" is provided, qvh will print some common gstreamer pipeline examples.
-			If --pipeline is provided, qvh will use the provided gstreamer pipeline instead of
-			displaying audio and video in a window.
+        gstreamer       If no additional param is provided, qvh will open a new window and push AV data to gstreamer.
+                        If "qvh gstreamer --examples" is provided, qvh will print some common gstreamer pipeline examples.
+                        If --pipeline is provided, qvh will use the provided gstreamer pipeline instead of
+                        displaying audio and video in a window.
+
+        diagnostics     The diagnostics mode is added for running longterm tests to debug and ensure stability.
+                        It will log several metrics and debug logs. Optionally specify a dump file with the --dump option that
+                        will store raw bytes of all messages. Be aware though, that this file will grow quite large over time.
 ```
 
-## 3. Technical Docs/ Roll your own implementation
+## 4. Technical Docs/ Roll your own implementation
+
+Qvh without Gstreamer is stable. I ran it for 16 hours straight on parallel devices and it worked flawlessly.
+
 QVH probably does something similar to what `QuickTime` and `com.apple.cmio.iOSScreenCaptureAssistant` are doing on MacOS.
 I have written some documentation here [doc/technical_documentation.md](https://github.com/danielpaulus/quicktime_video_hack/blob/master/doc/technical_documentation.md)
 So if you are just interested in the protocol or if you want to implement this in a different programming language than golang, read the docs.
 Also I have extracted binary dumps of all messages for writing unit tests and re-develop this in your preferred language in a test driven style.
 
-I have given up on windows support  :-)
+I have given up on windows support :-)
 ~~[Port to Windows](https://github.com/danielpaulus/quicktime_video_hack/tree/windows/windows) (I don't know why, but still people use Windows nowadays)~~ Did not find a way to do it
-
-
-

--- a/README.md
+++ b/README.md
@@ -52,47 +52,6 @@ Also, let me know if you have ideas what needs to be added.
 - For troubleshooting run `qvh diagnostics metrics.csv --dump=binary.bin` which will log all important and dump everything to files.
 - For just getting raw media output without Gstreamer involved use `qvh record out.h264 out.wav` or `qvh audio out.wav --wav` for audio only
 
-```
-Q.uickTime V.ideo H.ack (qvh) v0.6-beta
-
-Usage:
-  qvh devices [-v]
-  qvh activate [--udid=<udid>] [-v]
-  qvh record <h264file> <wavfile> [--udid=<udid>] [-v]
-  qvh audio <outfile> (--mp3 | --ogg | --wav) [--udid=<udid>] [-v]
-  qvh gstreamer [--pipeline=<pipeline>] [--examples] [--udid=<udid>] [-v]
-  qvh diagnostics <outfile> [--dump=<dumpfile>] [--udid=<udid>]
-  qvh --version | version
-
-
-Options:
-  -h --help       Show this screen.
-  -v              Enable verbose mode (debug logging).
-  --version       Show version.
-  --udid=<udid>   UDID of the device. If not specified, the first found device will be used automatically.
-
-The commands work as following:
-        devices         lists iOS devices attached to this host and tells you if video streaming was activated for them
-
-        activate        enables the video streaming config for the device specified by --udid
-
-        record          will start video&audio recording. Video will be saved in a raw h264 file playable by VLC.
-                        Audio will be saved in a uncompressed wav file. Run like: "qvh record /home/yourname/out.h264 /home/yourname/out.wav"
-
-        audio           Records only audio from the device. It does not change the status bar like the video recording mode does.
-                        The recorded audio will be saved in <outfile> with the selected format. Currently (--mp3 | --ogg | --wav) are supported.
-                        Adding more formats is trivial though so create an issue or a PR if you need something :-)
-
-        gstreamer       If no additional param is provided, qvh will open a new window and push AV data to gstreamer.
-                        If "qvh gstreamer --examples" is provided, qvh will print some common gstreamer pipeline examples.
-                        If --pipeline is provided, qvh will use the provided gstreamer pipeline instead of
-                        displaying audio and video in a window.
-
-        diagnostics     The diagnostics mode is added for running longterm tests to debug and ensure stability.
-                        It will log several metrics and debug logs. Optionally specify a dump file with the --dump option that
-                        will store raw bytes of all messages. Be aware though, that this file will grow quite large over time.
-```
-
 ## 4. Technical Docs/ Roll your own implementation
 
 QVH probably does something similar to what `QuickTime` and `com.apple.cmio.iOSScreenCaptureAssistant` are doing on MacOS.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 [![codecov](https://codecov.io/gh/danielpaulus/quicktime_video_hack/branch/master/graph/badge.svg)](https://codecov.io/gh/danielpaulus/quicktime_video_hack)
 [![Go Report](https://goreportcard.com/badge/github.com/danielpaulus/quicktime_video_hack)](https://goreportcard.com/report/github.com/danielpaulus/quicktime_video_hack)
 
-🎉🎉 New Release 0.5 is out, now with stable execution on Mac OS X, no more unplugging devices 🎉🎉🎉🎉🎉🎉
+Release 0.6
 
-Qvh without Gstreamer is stable. I ran it for 16 hours straight on parallel devices and it worked flawlessly.
-Before a 1.0 Release I need to see if Gstreamer is stable enough.
+- qvh without Gstreamer is finally stable. I ran it for 16 hours straight on parallel devices and it worked flawlessly.
+- before a 1.0 Release I need to see if Gstreamer is stable enough and maybe fix or switch to ffmpeg
+- Linux support is still a bit broken
 
 ## 1. What is this?
 
@@ -93,8 +94,6 @@ The commands work as following:
 ```
 
 ## 4. Technical Docs/ Roll your own implementation
-
-Qvh without Gstreamer is stable. I ran it for 16 hours straight on parallel devices and it worked flawlessly.
 
 QVH probably does something similar to what `QuickTime` and `com.apple.cmio.iOSScreenCaptureAssistant` are doing on MacOS.
 I have written some documentation here [doc/technical_documentation.md](https://github.com/danielpaulus/quicktime_video_hack/blob/master/doc/technical_documentation.md)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/danielpaulus/quicktime_video_hack/screencapture"
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
+	"github.com/danielpaulus/quicktime_video_hack/screencapture/diagnostics"
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/gstadapter"
 	"github.com/docopt/docopt-go"
 	log "github.com/sirupsen/logrus"
@@ -196,6 +197,13 @@ func recordAudioGst(outfile string, udid string, audiotype string) {
 
 func runDiagnostics(outfile string, dump bool, dumpFile string, udid string) {
 	log.Debugf("diagnostics mode: %s  dump:%t %s device:%s", outfile, dump, dumpFile, udid)
+	metricsFile, err := os.Create(outfile)
+	if err != nil {
+		log.Errorf("Could not open file '%s'", outfile)
+	}
+	defer metricsFile.Close()
+	consumer := diagnostics.NewDiagnosticsConsumer(metricsFile)
+	startWithConsumer(consumer, udid, false)
 }
 
 func recordAudioWav(outfile string, udid string) {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version = "v0.5-beta"
+const version = "v0.6-beta"
 
 func main() {
 	usage := fmt.Sprintf(`Q.uickTime V.ideo H.ack (qvh) %s
@@ -27,7 +27,7 @@ Usage:
   qvh record <h264file> <wavfile> [--udid=<udid>] [-v]
   qvh audio <outfile> (--mp3 | --ogg | --wav) [--udid=<udid>] [-v]
   qvh gstreamer [--pipeline=<pipeline>] [--examples] [--udid=<udid>] [-v]
-  qvh diagnostics <outfile> [--dump=<dumpfile>] [--udid=<udid>] [-v]
+  qvh diagnostics <outfile> [--dump=<dumpfile>] [--udid=<udid>]
   qvh --version | version
 
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/danielpaulus/quicktime_video_hack/screencapture"
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
@@ -202,7 +203,7 @@ func runDiagnostics(outfile string, dump bool, dumpFile string, udid string) {
 		log.Errorf("Could not open file '%s'", outfile)
 	}
 	defer metricsFile.Close()
-	consumer := diagnostics.NewDiagnosticsConsumer(metricsFile)
+	consumer := diagnostics.NewDiagnosticsConsumer(metricsFile, time.Second*10)
 	startWithConsumer(consumer, udid, false)
 }
 

--- a/main.go
+++ b/main.go
@@ -116,8 +116,11 @@ The commands work as following:
 
 	diagnostics, _ := arguments.Bool("diagnostics")
 	if diagnostics {
-		logfile, err := os.OpenFile(fmt.Sprintf("logfile-%d.log", time.Now().Unix()), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		log.SetLevel(log.DebugLevel)
+		logfileName := fmt.Sprintf("logfile-%d.log", time.Now().Unix())
+		logfile, err := os.OpenFile(logfileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err == nil {
+			println("logging to", logfileName, " execute: 'tail -f ", logfileName, "' for logs. Press CTRL+C to stop recording.")
 			log.SetOutput(logfile)
 		} else {
 			log.Info("Failed to log to file, using default stderr")

--- a/screencapture/diagnostics/consumer.go
+++ b/screencapture/diagnostics/consumer.go
@@ -2,8 +2,8 @@ package diagnostics
 
 import (
 	"fmt"
+	"io"
 	"log"
-	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -12,7 +12,7 @@ import (
 )
 
 type DiagnosticsConsumer struct {
-	file            *os.File
+	file            io.Writer
 	audioSamplesRcv uint64
 	videoSamplesRcv uint64
 	audioBytesRcv   uint64
@@ -20,7 +20,7 @@ type DiagnosticsConsumer struct {
 	mux             sync.Mutex
 }
 
-func NewDiagnosticsConsumer(outfile *os.File) *DiagnosticsConsumer {
+func NewDiagnosticsConsumer(outfile io.Writer) *DiagnosticsConsumer {
 	d := &DiagnosticsConsumer{file: outfile}
 	go fileWriter(d)
 	return d

--- a/screencapture/diagnostics/consumer.go
+++ b/screencapture/diagnostics/consumer.go
@@ -1,0 +1,78 @@
+package diagnostics
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
+)
+
+type DiagnosticsConsumer struct {
+	file            *os.File
+	audioSamplesRcv uint64
+	videoSamplesRcv uint64
+	audioBytesRcv   uint64
+	videoBytesRcv   uint64
+	mux             sync.Mutex
+}
+
+func NewDiagnosticsConsumer(outfile *os.File) *DiagnosticsConsumer {
+	d := &DiagnosticsConsumer{file: outfile}
+	go fileWriter(d)
+	return d
+}
+
+func fileWriter(d *DiagnosticsConsumer) {
+	d.file.Write([]byte("audioSamplesRcv, audioBytesRcv, videoSamplesRcv, videoBytesRcv, heapobjects, alloc"))
+
+	for {
+		time.Sleep(time.Second * 10)
+		audioSamplesRcv, audioBytesRcv, videoSamplesRcv, videoBytesRcv := readAndReset(d)
+		heapobjects, alloc := getMemStats()
+		csvLine := fmt.Sprintf("%d,%d,%d,%d,%d,%d", audioSamplesRcv, audioBytesRcv, videoSamplesRcv, videoBytesRcv, heapobjects, alloc)
+		_, err := d.file.Write([]byte(csvLine))
+		if err != nil {
+			log.Fatalf("Failed writing to metricsfile:%+v", err)
+		}
+	}
+}
+
+func getMemStats() (uint64, uint64) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapObjects, m.Alloc
+}
+
+func readAndReset(d *DiagnosticsConsumer) (uint64, uint64, uint64, uint64) {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+	audioSamplesRcv, audioBytesRcv, videoSamplesRcv, videoBytesRcv := d.audioSamplesRcv, d.audioBytesRcv, d.videoSamplesRcv, d.videoBytesRcv
+	d.audioSamplesRcv, d.audioBytesRcv, d.videoSamplesRcv, d.videoBytesRcv = 0, 0, 0, 0
+	return audioSamplesRcv, audioBytesRcv, videoSamplesRcv, videoBytesRcv
+}
+
+func (d *DiagnosticsConsumer) Consume(buf coremedia.CMSampleBuffer) error {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+	if buf.MediaType == coremedia.MediaTypeSound {
+		return d.consumeAudio(buf)
+	}
+
+	return d.consumeVideo(buf)
+}
+
+func (d *DiagnosticsConsumer) consumeAudio(buf coremedia.CMSampleBuffer) error {
+	d.audioSamplesRcv++
+	d.audioBytesRcv += uint64(len(buf.SampleData))
+	return nil
+}
+
+func (d *DiagnosticsConsumer) consumeVideo(buf coremedia.CMSampleBuffer) error {
+	d.videoSamplesRcv++
+	d.videoBytesRcv += uint64(len(buf.SampleData))
+	return nil
+}

--- a/screencapture/diagnostics/consumer_test.go
+++ b/screencapture/diagnostics/consumer_test.go
@@ -1,27 +1,42 @@
 package diagnostics_test
 
 import (
-	"bytes"
-	"log"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
 	"github.com/danielpaulus/quicktime_video_hack/screencapture/diagnostics"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConsumer(t *testing.T) {
-	buf := new(bytes.Buffer)
-	d := diagnostics.NewDiagnosticsConsumer(buf, time.Microsecond)
+	waiter := WriteWaiter{make(chan []byte, 100)}
+
+	d := diagnostics.NewDiagnosticsConsumer(waiter, time.Microsecond)
+	header := <-waiter.written
+	assert.Equal(t, diagnostics.CSVHeader, string(header))
 	audioBytes := 35
 	videoBytes := 89
 	audiobuf := coremedia.CMSampleBuffer{MediaType: coremedia.MediaTypeSound, SampleData: make([]byte, audioBytes)}
 	videobuf := coremedia.CMSampleBuffer{MediaType: coremedia.MediaTypeVideo, SampleData: make([]byte, videoBytes)}
 	d.Consume(audiobuf)
 	d.Consume(videobuf)
-	time.Sleep(time.Second)
+	data := <-waiter.written
 	d.Stop()
-	result := strings.Split(string(buf.Bytes()), "\n")
-	log.Fatal(result)
+	result := strings.Split(string(data), ",")
+	assert.Equal(t, result[0], "1")
+	assert.Equal(t, result[1], strconv.Itoa(audioBytes))
+	assert.Equal(t, result[2], "1")
+	assert.Equal(t, result[3], strconv.Itoa(videoBytes))
+}
+
+type WriteWaiter struct {
+	written chan []byte
+}
+
+func (w WriteWaiter) Write(p []byte) (n int, err error) {
+	w.written <- p
+	return len(p), nil
 }

--- a/screencapture/diagnostics/consumer_test.go
+++ b/screencapture/diagnostics/consumer_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestConsumer(t *testing.T) {
+	//buffered channel because Stop will block otherwise
 	waiter := WriteWaiter{make(chan []byte, 100)}
 
 	d := diagnostics.NewDiagnosticsConsumer(waiter, 0)

--- a/screencapture/diagnostics/consumer_test.go
+++ b/screencapture/diagnostics/consumer_test.go
@@ -1,0 +1,27 @@
+package diagnostics_test
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/quicktime_video_hack/screencapture/coremedia"
+	"github.com/danielpaulus/quicktime_video_hack/screencapture/diagnostics"
+)
+
+func TestConsumer(t *testing.T) {
+	buf := new(bytes.Buffer)
+	d := diagnostics.NewDiagnosticsConsumer(buf, time.Microsecond)
+	audioBytes := 35
+	videoBytes := 89
+	audiobuf := coremedia.CMSampleBuffer{MediaType: coremedia.MediaTypeSound, SampleData: make([]byte, audioBytes)}
+	videobuf := coremedia.CMSampleBuffer{MediaType: coremedia.MediaTypeVideo, SampleData: make([]byte, videoBytes)}
+	d.Consume(audiobuf)
+	d.Consume(videobuf)
+	time.Sleep(time.Second)
+	d.Stop()
+	result := strings.Split(string(buf.Bytes()), "\n")
+	log.Fatal(result)
+}

--- a/screencapture/discovery.go
+++ b/screencapture/discovery.go
@@ -246,6 +246,8 @@ func correct24CharacterSerial(usbSerial string) string {
 	return usbSerial
 }
 
+const sixteenTimesZero = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
 //ValidateUdid checks if a given udid is 25 or 40 characters long.
 //25 character udids must be of format xxxxxxxx-xxxxxxxxxxxxxxxx.
 //Serialnumbers on the usb host contain no dashes. As a convenience ValidateUdid
@@ -260,7 +262,9 @@ func ValidateUdid(udid string) (string, error) {
 		if strings.Index(udid, "-") != 8 {
 			return udid, fmt.Errorf("Invalid format for udid:%s 25 char UDIDs must contain a dash at position 8", udid)
 		}
-		return strings.Replace(udid, "-", "", 1), nil
+		removedDash := strings.Replace(udid, "-", "", 1)
+
+		return removedDash + sixteenTimesZero, nil
 	}
 	return udid, nil
 }

--- a/screencapture/discovery_test.go
+++ b/screencapture/discovery_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const iphoneXrXsStyleSerial = "xxxxxxxxxxxxxxxxxxxxxxxx"
+const iphoneXrXsStyleSerial = "xxxxxxxxxxxxxxxxxxxxxxxx\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 const iphoneXrXsStyleUdid = "xxxxxxxx-xxxxxxxxxxxxxxxx"
 const regularSerial = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
@@ -24,8 +24,8 @@ func TestSerialConvertedToCorrectUdid(t *testing.T) {
 func TestValidateUdid(t *testing.T) {
 	serial, err := screencapture.ValidateUdid(iphoneXrXsStyleUdid)
 	assert.NoError(t, err)
+	assert.Equal(t, 40, len(serial))
 	assert.Equal(t, iphoneXrXsStyleSerial, serial)
-
 	serial, err = screencapture.ValidateUdid(regularSerial)
 	assert.NoError(t, err)
 	assert.Equal(t, regularSerial, serial)

--- a/screencapture/usbadapter.go
+++ b/screencapture/usbadapter.go
@@ -28,7 +28,7 @@ func (usbAdapter *UsbAdapter) WriteDataToUsb(bytes []byte) {
 	if usbAdapter.Dump {
 		_, err := usbAdapter.DumpOutWriter.Write(bytes)
 		if err != nil {
-			log.Fatal("Failed dumping data:%v", err)
+			log.Fatalf("Failed dumping data:%v", err)
 		}
 	}
 }
@@ -124,7 +124,7 @@ func (usbAdapter *UsbAdapter) StartReading(device IosDevice, receiver UsbDataRec
 			if usbAdapter.Dump {
 				_, err := usbAdapter.DumpInWriter.Write(dataBuffer)
 				if err != nil {
-					log.Fatal("Failed dumping data:%v", err)
+					log.Fatalf("Failed dumping data:%v", err)
 				}
 			}
 			receiver.ReceiveData(dataBuffer)


### PR DESCRIPTION
For making sure qvh works stable over extended periods of time, this PR introduces the diagnostics command which allows:
-  recording metrics
- dumping all binary traffic two inbound and outbound files
- saving all logs to a file

Also I fixed hopefully the last iPhone Xr serial/udid mapping issue. 