### PR TITLE
Fix infinite loop when unable to re-open device after activating QT config

### DIFF
--- a/screencapture/activator.go
+++ b/screencapture/activator.go
@@ -40,14 +40,14 @@ func EnableQTConfig(device IosDevice) (IosDevice, error) {
 		device, err = device.ReOpen(ctx)
 		if err != nil {
 			log.Debugf("device not found:%s", err)
-			continue
+		} else {
+			break
 		}
 		i++
 		if i > 10 {
 			log.Debug("Failed activating config")
 			return IosDevice{}, fmt.Errorf("could not activate Quicktime Config for %s", usbSerial)
 		}
-		break
 	}
 	log.Debugf("QTConfig for %s activated", usbSerial)
 	return device, err


### PR DESCRIPTION
I notice that the intended behavior is to attempt to re-open a device 10 times and return an error if the USB context can not be reopened. However, the actual behavior is an infinite loop of trying to reopen the context. This PR prevents that infinite loop from happening and appropriately exits and logs after 10 tries. I encountered this code path on my own device and had to manually send Ctrl-C to retry the activation.